### PR TITLE
修正：命名変更

### DIFF
--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -15,45 +15,52 @@ class AuthController extends Controller
 {
     protected $userService;
 
+    //
     public function __construct(UserService $userService)
     {
         $this->userService = $userService;
     }
 
-    public function signup(CreateUserRequest $request)
+    //ユーザーの新規登録
+    public function signUp(CreateUserRequest $request)
     {
         $user = $this->userService->createUser($request->validated());
         return response()->json($user, 201);
     }
 
-    public function signin(LoginRequest $request)
-    {
+    //ユーザーのログイン
+    public function signIn(LoginRequest $request)
+     {
         $user = $this->userService->loginUser($request->validated());
+        
         // Sanctumトークンの生成と返却
         $token = $user->createToken('authToken')->plainTextToken;
         return response()->json(['token' => $token, 'user' => $user], 200);
       }
 
+    //ユーザーのログアウト
     public function logout(Request $request)
     {
         $request->user()->currentAccessToken()->delete();
         return response()->json(['message' => 'ログアウトしました。'], 200);
     }
 
-    // ログイン中のユーザー情報を取得するコントローラーメソッド
-    public function getUser(Request $request)
+    //ログイン中のユーザー情報を取得する
+    public function getUserData(Request $request)
     {
       $userId = $request->user()->id;
       return $this->userService->getUserById($userId);
     }
 
-    public function updateUser(UpdateUserRequest $request)
+    //ユーザー情報（PWを除く）の編集
+    public function updateUserData(UpdateUserRequest $request)
     {
-      $user = $this->userService->updateUser(Auth::id(), $request->validated());
+      $user = $this->userService->updateUserData(Auth::id(), $request->validated());
       return response()->json($user, 200);
     }
 
-    public function updatePassword(updatePasswordRequest $request)
+    //ユーザーパスワードの編集
+    public function updateUserPassword(updatePasswordRequest $request)
     {
       $currentPassword = $request->input('password');
       $newPassword = $request->input('newPassword');
@@ -62,6 +69,7 @@ class AuthController extends Controller
       return response()->json(['message'=> 'パスワードが更新されました。'], 200);
     }
 
+    //ユーザー自体の削除
     public function deleteUser()
     {
       $this->userService->deleteUser(Auth::id());

--- a/backend/app/Http/Controllers/SaunalogController.php
+++ b/backend/app/Http/Controllers/SaunalogController.php
@@ -20,14 +20,14 @@ class SaunalogController extends Controller
         $this->saunalogService = $saunalogService;
     }
 
-    //サウナログ一覧の表示
+    //ユーザーに紐づくサウナログ一覧の表示
     public function getUserSaunaLogs(Request $request)
     {
         $userId = $request->user()->id;
         return $this->saunalogService->getLogsByUser($userId);
     }
 
-    //特定のサウナログの表示（編集時fetchで使用）
+    //特定のサウナログの表示
     public function getSaunalogById($id)
     {
         return $this->saunalogService->findOne($id);

--- a/backend/app/Http/Controllers/SaunalogController.php
+++ b/backend/app/Http/Controllers/SaunalogController.php
@@ -21,34 +21,34 @@ class SaunalogController extends Controller
     }
 
     //ユーザーに紐づくサウナログ一覧の表示
-    public function getUserSaunaLogs(Request $request)
+    public function getLogs(Request $request)
     {
         $userId = $request->user()->id;
         return $this->saunalogService->getLogsByUser($userId);
     }
 
     //特定のサウナログの表示
-    public function getSaunalogById($id)
+    public function getLogById($id)
     {
-        return $this->saunalogService->findOne($id);
+        return $this->saunalogService->getLogById($id);
     }
 
     //サウナログの新規作成
-    public function createSaunalog(CreateSaunalogRequest $request)
+    public function create(CreateSaunalogRequest $request)
     {
         $user = $request->user();
-        return $this->saunalogService->create($request->validated(), $user);
+        return $this->saunalogService->createLog($request->validated(), $user);
     }
 
     //特定のサウナログの編集
-    public function updateSaunalogById($id, UpdateSaunalogRequest $request)
+    public function update($id, UpdateSaunalogRequest $request)
     {
-        return $this->saunalogService->updateSaunalog($id, $request->validated());
+        return $this->saunalogService->updateLogById($id, $request->validated());
     }
 
     //特定のサウナログの削除
-    public function destroySaunalogById($id)
+    public function delete($id)
     {
-        return $this->saunalogService->delete($id);
+        return $this->saunalogService->deleteLogById($id);
     }
 }

--- a/backend/app/Http/Controllers/SaunalogController.php
+++ b/backend/app/Http/Controllers/SaunalogController.php
@@ -20,29 +20,34 @@ class SaunalogController extends Controller
         $this->saunalogService = $saunalogService;
     }
 
-    public function index(Request $request)
+    //サウナログ一覧の表示
+    public function getUserSaunaLogs(Request $request)
     {
         $userId = $request->user()->id;
         return $this->saunalogService->getLogsByUser($userId);
     }
 
-    public function show($id)
+    //特定のサウナログの表示（編集時fetchで使用）
+    public function getSaunalogById($id)
     {
         return $this->saunalogService->findOne($id);
     }
 
-    public function store(CreateSaunalogRequest $request)
+    //サウナログの新規作成
+    public function createSaunalog(CreateSaunalogRequest $request)
     {
         $user = $request->user();
         return $this->saunalogService->create($request->validated(), $user);
     }
 
-    public function update($id, UpdateSaunalogRequest $request)
+    //特定のサウナログの編集
+    public function updateSaunalogById($id, UpdateSaunalogRequest $request)
     {
         return $this->saunalogService->updateSaunalog($id, $request->validated());
     }
 
-    public function destroy($id)
+    //特定のサウナログの削除
+    public function destroySaunalogById($id)
     {
         return $this->saunalogService->delete($id);
     }

--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -15,12 +15,12 @@ class UserController extends Controller
 {
     protected $userService;
 
-    //
     public function __construct(UserService $userService)
     {
         $this->userService = $userService;
     }
 
+    
     //ユーザーの新規登録
     public function signUp(CreateUserRequest $request)
     {

--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -11,7 +11,7 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
-class AuthController extends Controller
+class UserController extends Controller
 {
     protected $userService;
 

--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -46,31 +46,31 @@ class UserController extends Controller
     }
 
     //ログイン中のユーザー情報を取得する
-    public function getUserData(Request $request)
+    public function get(Request $request)
     {
       $userId = $request->user()->id;
       return $this->userService->getUserById($userId);
     }
 
     //ユーザー情報（PWを除く）の編集
-    public function updateUserData(UpdateUserRequest $request)
+    public function update(UpdateUserRequest $request)
     {
-      $user = $this->userService->updateUserData(Auth::id(), $request->validated());
+      $user = $this->userService->updateUser(Auth::id(), $request->validated());
       return response()->json($user, 200);
     }
 
     //ユーザーパスワードの編集
-    public function updateUserPassword(updatePasswordRequest $request)
+    public function updatePassword(updatePasswordRequest $request)
     {
       $currentPassword = $request->input('password');
       $newPassword = $request->input('newPassword');
 
-      $user = $this->userService->updateUserPassword(Auth::id(), $currentPassword, $newPassword);
+      $user = $this->userService->updatePassword(Auth::id(), $currentPassword, $newPassword);
       return response()->json(['message'=> 'パスワードが更新されました。'], 200);
     }
 
     //ユーザー自体の削除
-    public function deleteUser()
+    public function delete()
     {
       $this->userService->deleteUser(Auth::id());
       return response()->json(['message'=> 'ユーザーが削除されました。'], 200);

--- a/backend/app/Http/Requests/UpdateSaunalogRequest.php
+++ b/backend/app/Http/Requests/UpdateSaunalogRequest.php
@@ -22,7 +22,7 @@ class UpdateSaunalogRequest extends FormRequest
         ];
     }
 
-    public function message()
+    public function messages()
     {
         return [
             'name.required' => '名前は入力必須です',

--- a/backend/app/Services/SaunalogService.php
+++ b/backend/app/Services/SaunalogService.php
@@ -10,16 +10,21 @@ use Illuminate\Database\Eloquent\Collection;
 
 class SaunalogService 
 {
+
+    //ユーザーに紐づくサウナログ一覧の表示
     public function getLogsByUser($userId): Collection 
     {
       return Saunalog::where('userId', $userId)->get();
     }
 
+
+    //特定のサウナログの表示
     public function findOne($id): ?Saunalog
     {
       return Saunalog::find($id);
     }
 
+    //サウナログの新規作成
     public function create(array $data, User $user): Saunalog
     {
       $saunalog = new Saunalog($data);
@@ -29,6 +34,7 @@ class SaunalogService
       return $saunalog;
     }
 
+    //サウナログの編集
     public function updateSaunalog($id, array $data): Saunalog
     {
       $saunalog = Saunalog::find($id);
@@ -36,6 +42,7 @@ class SaunalogService
       return $saunalog;
     }
 
+    //サウナログの削除
     public function delete($id): bool
     {
       $saunalog = Saunalog::find($id);

--- a/backend/app/Services/SaunalogService.php
+++ b/backend/app/Services/SaunalogService.php
@@ -19,13 +19,13 @@ class SaunalogService
 
 
     //特定のサウナログの表示
-    public function findOne($id): ?Saunalog
+    public function getLogById($id): ?Saunalog
     {
       return Saunalog::find($id);
     }
 
     //サウナログの新規作成
-    public function create(array $data, User $user): Saunalog
+    public function createLog(array $data, User $user): Saunalog
     {
       $saunalog = new Saunalog($data);
       $saunalog->user()->associate($user);
@@ -35,7 +35,7 @@ class SaunalogService
     }
 
     //サウナログの編集
-    public function updateSaunalog($id, array $data): Saunalog
+    public function updateLogById($id, array $data): Saunalog
     {
       $saunalog = Saunalog::find($id);
       $saunalog->update($data);
@@ -43,7 +43,7 @@ class SaunalogService
     }
 
     //サウナログの削除
-    public function delete($id): bool
+    public function deleteLogById($id): bool
     {
       $saunalog = Saunalog::find($id);
       return $saunalog->delete();

--- a/backend/app/Services/UserService.php
+++ b/backend/app/Services/UserService.php
@@ -37,7 +37,7 @@ class UserService
     }
 
     //ユーザー情報（PWを除く）の編集
-    public function updateUseData($userId, array $data): User
+    public function updateUser($userId, array $data): User
     {
       $user = $this->getUserById($userId);
       $user->update($data);
@@ -45,7 +45,7 @@ class UserService
     }
 
     //パスワードの編集
-    public function updateUserPassword($userId, $currentPassword, $newPassword)
+    public function updatePassword($userId, $currentPassword, $newPassword)
     {
       $user = $this->getUserById($userId);
 

--- a/backend/app/Services/UserService.php
+++ b/backend/app/Services/UserService.php
@@ -34,7 +34,7 @@ class UserService
       return $user;
     }
 
-    public function updateUser($userId, array $data): User
+    public function updateUseData($userId, array $data): User
     {
       $user = $this->getUserById($userId);
       $user->update($data);

--- a/backend/app/Services/UserService.php
+++ b/backend/app/Services/UserService.php
@@ -11,12 +11,13 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class UserService
 {
-
+    //新規ユーザー作成
     public function createUser(array $data): User
     {
       return User::createUser($data);
     }
 
+    //ログイン
     public function loginUser(array $credentials)
     {
       if(!Auth::attempt($credentials)) {
@@ -25,6 +26,7 @@ class UserService
       return Auth::user();
     }
 
+    //ログイン中のユーザー情報を取得する
     public function getUserById($userId): User
     {
       $user = User::find($userId);
@@ -34,6 +36,7 @@ class UserService
       return $user;
     }
 
+    //ユーザー情報（PWを除く）の編集
     public function updateUseData($userId, array $data): User
     {
       $user = $this->getUserById($userId);
@@ -41,6 +44,7 @@ class UserService
       return $user;
     }
 
+    //パスワードの編集
     public function updateUserPassword($userId, $currentPassword, $newPassword)
     {
       $user = $this->getUserById($userId);
@@ -54,6 +58,7 @@ class UserService
       return $user;
     }
 
+    //ユーザーの削除
     public function deleteUser($userId)
     {
       $user = $this->getUserById($userId);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -10,19 +10,10 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-// SaunalogController ルート
-Route::middleware('auth:sanctum')->group(function () {
-    Route::get('/saunalog', [SaunalogController::class, 'getUserSaunaLogs']);
-    Route::get('/saunalog/{id}', [SaunalogController::class, 'getSaunalogById']);
-    Route::post('/saunalog', [SaunalogController::class, 'createSaunalog']);
-    Route::put('/saunalog/{id}', [SaunalogController::class, 'updateSaunalogById']);
-    Route::delete('/saunalog/{id}', [SaunalogController::class, 'destroySaunalogById']);
-});
-
-
 
 // UserControllerのルート
 Route::controller(UserController::class)->group(function () {
+
     // ユーザー登録
     Route::post('/signup', 'signUp');
 
@@ -43,4 +34,24 @@ Route::controller(UserController::class)->group(function () {
 
     // ユーザーの削除
     Route::delete('/delete-user', 'deleteUser')->middleware('auth:sanctum');
+});
+
+
+// SaunalogControllerのルート
+Route::middleware('auth:sanctum')->group(function () {
+
+    //ユーザーに紐づくサウナログの一覧の表示
+    Route::get('/saunalog', [SaunalogController::class, 'getUserSaunaLogs']);
+
+    //特定のサウナログの表示
+    Route::get('/saunalog/{id}', [SaunalogController::class, 'getSaunalogById']);
+
+    //サウナログの新規作成
+    Route::post('/saunalog', [SaunalogController::class, 'createSaunalog']);
+
+    //サウナログの編集
+    Route::put('/saunalog/{id}', [SaunalogController::class, 'updateSaunalogById']);
+
+    //サウナログの削除
+    Route::delete('/saunalog/{id}', [SaunalogController::class, 'destroySaunalogById']);
 });

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -11,27 +11,35 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 // SaunalogController ルート
-Route::middleware('auth:sanctum')->apiResource('saunalog', SaunalogController::class);
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/saunalog', [SaunalogController::class, 'getUserSaunaLogs']);
+    Route::get('/saunalog/{id}', [SaunalogController::class, 'getSaunalogById']);
+    Route::post('/saunalog', [SaunalogController::class, 'createSaunalog']);
+    Route::put('/saunalog/{id}', [SaunalogController::class, 'updateSaunalogById']);
+    Route::delete('/saunalog/{id}', [SaunalogController::class, 'destroySaunalogById']);
+});
+
+
 
 // AuthControllerのルート
 Route::controller(AuthController::class)->group(function () {
     // ユーザー登録
-    Route::post('/signup', 'signup');
+    Route::post('/signup', 'signUp');
 
     // ログイン
-    Route::post('/signin', 'signin');
+    Route::post('/signin', 'signIn');
 
     // ログアウト
     Route::post('/logout', 'logout')->middleware('auth:sanctum');
 
     // ユーザー情報の取得
-    Route::get('/getUser', 'getUser')->middleware('auth:sanctum');;
+    Route::get('/getUser', 'getUserData')->middleware('auth:sanctum');;
 
     // ユーザー情報の更新
-    Route::put('/update-user', 'updateUser')->middleware('auth:sanctum');
+    Route::put('/update-user', 'updateUserData')->middleware('auth:sanctum');
 
     // パスワードの更新
-    Route::put('/update-password', 'updatePassword')->middleware('auth:sanctum');
+    Route::put('/update-password', 'updateUserPassword')->middleware('auth:sanctum');
 
     // ユーザーの削除
     Route::delete('/delete-user', 'deleteUser')->middleware('auth:sanctum');

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -24,16 +24,16 @@ Route::controller(UserController::class)->group(function () {
     Route::post('/logout', 'logout')->middleware('auth:sanctum');
 
     // ユーザー情報の取得
-    Route::get('/getUser', 'getUserData')->middleware('auth:sanctum');;
+    Route::get('/getUser', 'get')->middleware('auth:sanctum');;
 
     // ユーザー情報の更新
-    Route::put('/update-user', 'updateUserData')->middleware('auth:sanctum');
+    Route::put('/update-user', 'update')->middleware('auth:sanctum');
 
     // パスワードの更新
-    Route::put('/update-password', 'updateUserPassword')->middleware('auth:sanctum');
+    Route::put('/update-password', 'updatePassword')->middleware('auth:sanctum');
 
     // ユーザーの削除
-    Route::delete('/delete-user', 'deleteUser')->middleware('auth:sanctum');
+    Route::delete('/delete-user', 'delete')->middleware('auth:sanctum');
 });
 
 
@@ -41,17 +41,17 @@ Route::controller(UserController::class)->group(function () {
 Route::middleware('auth:sanctum')->group(function () {
 
     //ユーザーに紐づくサウナログの一覧の表示
-    Route::get('/saunalog', [SaunalogController::class, 'getUserSaunaLogs']);
+    Route::get('/saunalog', [SaunalogController::class, 'getLogs']);
 
     //特定のサウナログの表示
-    Route::get('/saunalog/{id}', [SaunalogController::class, 'getSaunalogById']);
+    Route::get('/saunalog/{id}', [SaunalogController::class, 'getLogById']);
 
     //サウナログの新規作成
-    Route::post('/saunalog', [SaunalogController::class, 'createSaunalog']);
+    Route::post('/saunalog', [SaunalogController::class, 'create']);
 
     //サウナログの編集
-    Route::put('/saunalog/{id}', [SaunalogController::class, 'updateSaunalogById']);
+    Route::put('/saunalog/{id}', [SaunalogController::class, 'update']);
 
     //サウナログの削除
-    Route::delete('/saunalog/{id}', [SaunalogController::class, 'destroySaunalogById']);
+    Route::delete('/saunalog/{id}', [SaunalogController::class, 'delete']);
 });

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,7 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\SaunalogController;
-use App\Http\Controllers\AuthController;
+use App\Http\Controllers\UserController;
 
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
@@ -21,8 +21,8 @@ Route::middleware('auth:sanctum')->group(function () {
 
 
 
-// AuthControllerのルート
-Route::controller(AuthController::class)->group(function () {
+// UserControllerのルート
+Route::controller(UserController::class)->group(function () {
     // ユーザー登録
     Route::post('/signup', 'signUp');
 

--- a/frontend/pages/auth/login.vue
+++ b/frontend/pages/auth/login.vue
@@ -29,9 +29,6 @@
             <v-btn to="/" >戻る</v-btn>
           </v-card-actions>
         </v-form>
-        <p>
-          新規登録は<nuxt-link to="/auth/signup">こちら</nuxt-link>
-        </p>
       </v-card-text>
     </v-card>
   </v-layout>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -10,7 +10,8 @@
           <v-card-actions>
             <v-row style="text-align: center">
               <v-col>
-                <v-btn to="/auth/login"  class="primary my-5" min-width="300">ログインまたは新規登録</v-btn>
+                <v-btn to="/auth/login"  class="primary my-5" min-width="300">ログイン</v-btn>
+                <v-btn to="/auth/signUp"  class="primary my-5" min-width="300">新規登録</v-btn>
               </v-col>
             </v-row>
           </v-card-actions>


### PR DESCRIPTION
メソッド名の命名を変更
・上記ファイルのメソッド名をキャメルケースに変更
・routeディレクトリのapi.phpのルーティングを変更 
・saunalogControllerのルーティングをapiResourseから特定のメソッドをそれぞれで指定するよう変更
・Controller内のメソッド名をあえて抽象化し、Service内のメソッド名を明瞭化。