### PR TITLE
修正：認可エラーのデバッグ、単体テストの追加

### DIFF
--- a/backend/app/Http/Controllers/SaunalogController.php
+++ b/backend/app/Http/Controllers/SaunalogController.php
@@ -73,7 +73,7 @@ class SaunalogController extends Controller
     public function update($id, UpdateSaunalogRequest $request)
     {
         $saunalog = Saunalog::findOrFail($id); // IDを使ってサウナログのインスタンスを取得
-        $this->authorize('update', $saunalog); 
+        $this->authorize('update', [Saunalog::class, $saunalog->userId]); 
         try {
             return $this->saunalogService->updateLogById($id, $request->validated());
         } catch(NotFoundException $e) {
@@ -86,7 +86,7 @@ class SaunalogController extends Controller
     public function delete($id)
     {
         $saunalog = Saunalog::findOrFail($id);
-        $this->authorize('delete', $saunalog);
+        $this->authorize('delete', [Saunalog::class, $saunalog->userId]);
         try {
             return $this->saunalogService->deleteLogById($id);
         } catch(NotFoundException $e) {

--- a/backend/app/Policies/SaunaLogPolicy.php
+++ b/backend/app/Policies/SaunaLogPolicy.php
@@ -35,17 +35,17 @@ class SaunalogPolicy
     /**
      * Determine whether the user can update the model.
      */
-    public function update(User $user, Saunalog $saunalog): bool
+    public function update(User $user, int $saunalogUserId): bool
     {
-        return $user->id === $saunalog->userId;
+        return $user->id === $saunalogUserId;
     }
 
     /**
      * Determine whether the user can delete the model.
      */
-    public function delete(User $user, Saunalog $saunalog): bool
+    public function delete(User $user, int $saunalogUserId): bool
     {
-        return $user->id === $saunalog->userId;
+        return $user->id === $saunalogUserId;
     }
 
     /**

--- a/backend/app/Providers/AuthServiceProvider.php
+++ b/backend/app/Providers/AuthServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 // use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
+
 class AuthServiceProvider extends ServiceProvider
 {
     /**

--- a/backend/tests/Feature/SaunalogControllerTest.php
+++ b/backend/tests/Feature/SaunalogControllerTest.php
@@ -17,16 +17,27 @@ class SaunalogControllerTest extends TestCase
 
     use RefreshDatabase;
 
-    //すべてのサウナログの一覧表示の正常テスト
+    //すべてのサウナログのページネーションを使用した一覧表示の正常テスト
     public function testGetAllLogs()
     {
         $user = User::factory()->create();
-        $saunalog = Saunalog::factory()->count(3)->create(['userId' => $user->id]);
+        $saunalog = Saunalog::factory()->count(5)->create(['userId' => $user->id]);
         $this->actingAs($user);
 
-        $response = $this->getJson('/api/saunalog/all');
-        $response->assertStatus(200)
-                 ->assertJsonCount(3);   
+        $response = $this->getJson('/api/saunalog/all?page=1&limit=5');
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+           'logs'=> [
+                '*' => ['id', 'name', 'area', 'rank', 'comment', 'userId']
+           ],
+           'totalPages',
+           'currentPage',
+        ]);
+        $response->assertJson([
+            'totalPages' => 1,
+            'currentPage' => 1,
+        ]);
+        $this->assertCount(5, Saunalog::all());   
     }
 
 


### PR DESCRIPTION
・サウナログを作成したユーザーが編集、削除できない403認可エラーを修正
・ページネーションを含むサウナログのgetメソッドのテスト追加