### PR TITLE
修正：サウナログの編集ページを一部修正

### DIFF
--- a/backend/app/Exceptions/Handler.php
+++ b/backend/app/Exceptions/Handler.php
@@ -27,6 +27,8 @@ class Handler extends ExceptionHandler
             return response()->json(['message' => $exception->getMessage()], 401);
         } elseif ($exception instanceof \App\Exceptions\NotFoundException) {
             return response()->json(['message' => $exception->getMessage()], 404);
+        } elseif ($exception instanceof \Illuminate\Auth\Access\AuthorizationException) {
+            return response()->json(['message' => 'Admin権限を持つユーザーか、作成者しか編集・削除できません。権限を今一度お確かめください。'], 403);
         }
         // その他の例外に対するデフォルトの処理を維持
         return parent::render($request, $exception);

--- a/backend/app/Http/Controllers/SaunalogController.php
+++ b/backend/app/Http/Controllers/SaunalogController.php
@@ -72,8 +72,8 @@ class SaunalogController extends Controller
     //特定のサウナログの編集
     public function update($id, UpdateSaunalogRequest $request)
     {
-        // $saunalog = Saunalog::findOrFail($id); // IDを使ってサウナログのインスタンスを取得
-        // $this->authorize('update', $saunalog); 
+        $saunalog = Saunalog::findOrFail($id); // IDを使ってサウナログのインスタンスを取得
+        $this->authorize('update', $saunalog); 
         try {
             return $this->saunalogService->updateLogById($id, $request->validated());
         } catch(NotFoundException $e) {

--- a/frontend/.nuxt/routes.json
+++ b/frontend/.nuxt/routes.json
@@ -3,56 +3,48 @@
     "name": "editPassword",
     "path": "/editPassword",
     "component": "/Users/matsushitahiroki/Documents/codefile/sauna_log2/sauna_log/frontend/pages/editPassword.vue",
-    "chunkName": "pages/editPassword",
-    "_name": "_5cce9434"
+    "chunkName": "pages/editPassword"
   },
   {
     "name": "editUser",
     "path": "/editUser",
     "component": "/Users/matsushitahiroki/Documents/codefile/sauna_log2/sauna_log/frontend/pages/editUser.vue",
-    "chunkName": "pages/editUser",
-    "_name": "_9e77d438"
+    "chunkName": "pages/editUser"
   },
   {
     "name": "list",
     "path": "/list",
     "component": "/Users/matsushitahiroki/Documents/codefile/sauna_log2/sauna_log/frontend/pages/list/index.vue",
-    "chunkName": "pages/list/index",
-    "_name": "_75858560"
+    "chunkName": "pages/list/index"
   },
   {
     "name": "register",
     "path": "/register",
     "component": "/Users/matsushitahiroki/Documents/codefile/sauna_log2/sauna_log/frontend/pages/register.vue",
-    "chunkName": "pages/register",
-    "_name": "_7917f6dc"
+    "chunkName": "pages/register"
   },
   {
     "name": "auth-login",
     "path": "/auth/login",
     "component": "/Users/matsushitahiroki/Documents/codefile/sauna_log2/sauna_log/frontend/pages/auth/login.vue",
-    "chunkName": "pages/auth/login",
-    "_name": "_157ac8f1"
+    "chunkName": "pages/auth/login"
   },
   {
     "name": "auth-signUp",
     "path": "/auth/signUp",
     "component": "/Users/matsushitahiroki/Documents/codefile/sauna_log2/sauna_log/frontend/pages/auth/signUp.vue",
-    "chunkName": "pages/auth/signUp",
-    "_name": "_a0c5a340"
+    "chunkName": "pages/auth/signUp"
   },
   {
     "name": "index",
     "path": "/",
     "component": "/Users/matsushitahiroki/Documents/codefile/sauna_log2/sauna_log/frontend/pages/index.vue",
-    "chunkName": "pages/index",
-    "_name": "_e654061a"
+    "chunkName": "pages/index"
   },
   {
     "name": "list-id",
     "path": "/list/:id",
     "component": "/Users/matsushitahiroki/Documents/codefile/sauna_log2/sauna_log/frontend/pages/list/_id.vue",
-    "chunkName": "pages/list/_id",
-    "_name": "_5acb5890"
+    "chunkName": "pages/list/_id"
   }
 ]

--- a/frontend/pages/list/_id.vue
+++ b/frontend/pages/list/_id.vue
@@ -4,7 +4,7 @@
   <v-layout align-center justify-center>
     <v-card elevation="16" width="600px" class="mx-auto mt-5" color="" shaped>
       <v-card-title>
-        <h2 class="mx-auto">登録データの編集</h2>
+        <h4 class="mx-auto">サウナログの詳細ページ</h4>
       </v-card-title>
       <v-card-text>
         <v-form>
@@ -51,20 +51,28 @@
               class="font-weight-bold"
               >戻る</v-btn
             >
-            
           </v-card-actions>
         </v-form>
       </v-card-text>
+      <div>
+        <sauna-map :key="log ? log.id : 0" :log-id="log.id" :saunaName="log.name"></sauna-map>
+      </div>
     </v-card>
   </v-layout>
 </template>
 
 <script>
+import SaunaMap from '@/components/SaunaMap';
+
+
 export default {
   head() {
     return {
       title: 'Saunalog-Edit'
     }
+  },
+  components: {
+    SaunaMap,
   },
   data() {
     return {

--- a/frontend/pages/list/index.vue
+++ b/frontend/pages/list/index.vue
@@ -31,7 +31,7 @@
           <v-list dense>
             <v-list-item-group>
               <div id="map-section">
-                <v-list-item v-for="log in saunaLogs" :key="log.id" @click="selectLog(log)">
+                <v-list-item v-for="log in saunaLogs" :key="log.id" :to="`/list/${log.id}`">
                 <v-list-item-content>
                   <v-list-item-title  style="font-size: 16px;">{{ log.name }}</v-list-item-title>
                   <v-list-item-subtitle>エリア：{{ log.area }}</v-list-item-subtitle>
@@ -40,12 +40,9 @@
                   <v-list-item-subtitle>投稿者：{{ log.user.username }}</v-list-item-subtitle>
                 </v-list-item-content>
                 <v-list-item-action v-if="user && user.roles && (user.roles.some(role => role.name === 'admin') || log.user.id === user.id)">
-                  <v-btn icon :to="`/list/${log.id}`">
-                    <v-icon color="green">mdi-pencil</v-icon>
-                  </v-btn>
-                  <v-btn icon @click="() => deleteLog(log.id)">
+                <v-btn icon @click="() => deleteLog(log.id)">
                     <v-icon color="red">mdi-delete</v-icon>
-                  </v-btn>
+                </v-btn>
                 </v-list-item-action>
               </v-list-item>
              </div>


### PR DESCRIPTION
＜修正内容＞
・サウナログの編集ページにGoogleマップを追加
・サウナログの編集ページへの導線を編集ボタンではなく、リストのクリック遷移に変更
・Policyの追加（Admin権限を持つユーザーか、作成者しか編集・削除できない）
・403認可エラー時のメッセージを日本語にカスタマイズ